### PR TITLE
Fixed bug that causes array out of bounds

### DIFF
--- a/CUEAudioVisualizer/Plugins/SpectrumPlugin.cs
+++ b/CUEAudioVisualizer/Plugins/SpectrumPlugin.cs
@@ -41,7 +41,7 @@ namespace CUEAudioVisualizer.Plugins
                 RectangleF keyRect = key.LedRectangle;
                 PointF keyCenterPos = new PointF(keyRect.Location.X + (keyRect.Width / 2f), keyRect.Location.Y + (keyRect.Height / 2f)); //Sample center of key
                 int barSampleIndex = (int)Math.Floor(barCount * (keyCenterPos.X / kbWidth)); //Calculate bar sampling index
-                float curBarHeight = 1f - Utility.Clamp(Host.SmoothedBarData[barSampleIndex] * 1.5f, 0f, 1f); //Scale values up a bit and clamp to 1f. I also invert this value since the keyboard is laid out with topleft being point 0,0
+                float curBarHeight = 1f - Utility.Clamp(Host.SmoothedBarData[barSampleIndex - 1] * 1.5f, 0f, 1f); //Scale values up a bit and clamp to 1f. I also invert this value since the keyboard is laid out with topleft being point 0,0
                 float keyVerticalPos = (keyCenterPos.Y / kbHeight);
 
                 if (curBarHeight <= keyVerticalPos)


### PR DESCRIPTION
The array index is zero based, which means it goes from 0 to 999, yet the barSampleIndex integer goes from 1 to 1000 which caused an array of bounds error on startup. Forcing the outcome to be always - 1 fixes this (so 500 becomes 499, 1 becomes 0 and 1000 becomes 999).